### PR TITLE
Add mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # autovpn
 
 `autovpn` is a tool to automatically connect you to a random VPN in a country
-of your choice. It uses `openvpn` to connect you to a server obtained
+of your choice. It uses [openvpn][openvpn] to connect you to a server obtained
 from [VPN Gate](http://www.vpngate.net/en/).
 
 ### Compiling
@@ -23,7 +23,9 @@ It's Go. What do you expect?
 
 ### Requirements
 
-This requires `openvpn`. To install this on a `yum`-based distro:
+This requires [openvpn][openvpn].
+
+To install this on a `yum`-based distro:
 
 ```bash
 $ sudo dnf install openvpn
@@ -35,7 +37,16 @@ If you're on a `apt`-based distro:
 $ sudo apt-get install openvpn
 ```
 
-Tested and works on Fedora 23. Dunno about Windows. Patches welcome.
+And on Mac OSX:
+
+```bash
+$ brew install openvpn
+$ # add the executable to your path
+$ export PATH=$(brew --prefix openvpn)/sbin:$PATH
+```
+
+Tested and works on Fedora 23 and MacOS Sierra `10.12.6`. Dunno about
+Windows. Patches welcome.
 
 ### Usage
 
@@ -85,3 +96,6 @@ real and secure VPN. This is mostly a fun tool to get a VPN for a few minutes.
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ```
+
+
+[openvpn]: https://github.com/OpenVPN/openvpn


### PR DESCRIPTION
## Context

Running `autovpn` requires to have `openvpn` available in the `$PATH`, which is not obvious on Mac. Hence the updated readme to address #10 